### PR TITLE
support max_bytes for docker partial log 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ FROM registry.cn-hangzhou.aliyuncs.com/terminus/terminus-centos:base
 
 WORKDIR /app
 
+ENV GODEBUG="madvdontneed=1"
+
 COPY --from=build /root/build/entrypoint.sh /app/
 COPY --from=build /root/build/filebeat/filebeat /app/
 COPY --from=build /root/build/filebeat/conf/* /app/conf/

--- a/filebeat/conf/filebeat.yml
+++ b/filebeat/conf/filebeat.yml
@@ -14,19 +14,18 @@ filebeat.inputs:
     stream: all
     encoding: utf-8
     ignore_older: 24h
-    max_bytes: 51200
+    max_bytes: ${INPUT_MAX_BYTES:51200}
     # 只要包含时间文本和日志等级文本，则认为是日志行
     multiline.patterns:
       - '(.*?)(\d{4}-\d{2}-\d{2}(\s|T)\d{2}:\d{2}:\d{2})(.*?)([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|DEBU|[Nn]otice|NOTICE|[Ii]nfo|INFO|[Ww]arn(?:ing)?|WARN(?:ING)?|[Ee]rr(?:or)?|ERR(?:OR)?|[Cc]rit(?:ical)?|CRIT(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|[Ee]merg(?:ency)?|EMERG(?:ENCY){1})(.*?)'
       - '(.*?)([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|DEBU|[Nn]otice|NOTICE|[Ii]nfo|INFO|[Ww]arn(?:ing)?|WARN(?:ING)?|[Ee]rr(?:or)?|ERR(?:OR)?|[Cc]rit(?:ical)?|CRIT(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|[Ee]merg(?:ency)?|EMERG(?:ENCY){1})(.*?)(\d{4}-\d{2}-\d{2}(\s|T)\d{2}:\d{2}:\d{2})(.*?)'
     multiline.negate: false
     multiline.match: after
-    multiline.max_lines: 500
+    multiline.max_lines: ${INPUT_MULTILINE_MAX_LINES:500}
     multiline.timeout: 1s
-    close_inactive: 10m
-    close_removed: true
-    close_timeout: 30m
-    clean_removed: true
+    close_inactive: ${INPUT_CLOSE_INACTIVE:5m}
+    close_removed: ${INPUT_CLOSE_REMOVE:false}
+    close_timeout: ${INPUT_CLOSE_TIMEOUT:30m}
 queue:
   mem:
     events: ${QUEUE_MEM_EVENTS:1024}

--- a/filebeat/conf/filebeat.yml
+++ b/filebeat/conf/filebeat.yml
@@ -24,7 +24,8 @@ filebeat.inputs:
     multiline.max_lines: ${INPUT_MULTILINE_MAX_LINES:500}
     multiline.timeout: 1s
     close_inactive: ${INPUT_CLOSE_INACTIVE:5m}
-    close_removed: ${INPUT_CLOSE_REMOVE:false}
+    # default false, avoid log-lose when filebeat consume can't catch up log produce
+    close_removed: ${INPUT_CLOSE_REMOVED:false}
     close_timeout: ${INPUT_CLOSE_TIMEOUT:30m}
 queue:
   mem:

--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -71,12 +71,7 @@ type config struct {
 	JSON           *readjson.Config        `config:"json"`
 
 	// Hidden on purpose, used by the docker input:
-	DockerJSON *struct {
-		Stream   string `config:"stream"`
-		Partial  bool   `config:"partial"`
-		Format   string `config:"format"`
-		CRIFlags bool   `config:"cri_flags"`
-	} `config:"docker-json"`
+	DockerJSON *readjson.DockerJsonConfig `config:"docker-json"`
 }
 
 type LogConfig struct {

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -682,7 +682,7 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 
 	if h.config.DockerJSON != nil {
 		// Docker json-file format, add custom parsing to the pipeline
-		r = readjson.New(r, h.config.DockerJSON.Stream, h.config.DockerJSON.Partial, h.config.DockerJSON.Format, h.config.DockerJSON.CRIFlags)
+		r = readjson.New(r, h.config.MaxBytes, h.config.DockerJSON)
 	}
 
 	if h.config.JSON != nil {

--- a/libbeat/reader/readjson/docker_json_config.go
+++ b/libbeat/reader/readjson/docker_json_config.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readjson
+
+// Config holds the options a JSON reader.
+type DockerJsonConfig struct {
+	Stream   string `config:"stream"`
+	Partial  bool   `config:"partial"`
+	Format   string `config:"format"`
+	CRIFlags bool   `config:"cri_flags"`
+}
+
+// Validate validates the Config option for JSON reader.
+func (c *DockerJsonConfig) Validate() error {
+	return nil
+}


### PR DESCRIPTION
- Enhancement

## What does this PR do?

if docker contrainer print a very large log message, it will split it to multi log line, which will result in OOM.

make `max_bytes` effect to this scenario

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
avoid OOM when encounter large log message

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
